### PR TITLE
fix(test_lambda): disable creation of package for lambda

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -3,18 +3,17 @@ data "archive_file" "lambda_package" {
   type        = "zip"
   source_dir  = var.lambda_source_path
   output_path = var.lambda_output_path
-  
-  
 }
 
 module "test_lambda" {
-  source = "terraform-aws-modules/lambda/aws"  # This is an example, replace with your actual module path
+  source        = "terraform-aws-modules/lambda/aws" # This is an example, replace with your actual module path
   function_name = var.lambda_name
   description   = "A Lambda function to test my knowledge"
   runtime       = "python3.10"
   handler       = "lambda_function.lambda_handler"
 
   # Use the zip ( from outputh) variable for the source path in the module
-  source_path   = var.lambda_output_path
+  create_package         = false
+  local_existing_package = var.lambda_output_path
 }
 


### PR DESCRIPTION
`lambda_package` creates the zip for the python code, therefore the module does not need to create the package again. `create_package` set to `false` and `local_existing_package` included to point to zipped file location